### PR TITLE
Add `box-sizing: border-box;` to Container

### DIFF
--- a/src/components/__tests__/__snapshots__/container.test.js.snap
+++ b/src/components/__tests__/__snapshots__/container.test.js.snap
@@ -5,6 +5,7 @@ exports[`<Container /> should render default style correctly 1`] = `
   margin-right: auto;
   margin-left: auto;
   max-width: 100%;
+  box-sizing: border-box;
 }
 
 @media only screen and (min-width:1rem) {

--- a/src/components/grid/container.js
+++ b/src/components/grid/container.js
@@ -11,6 +11,7 @@ const Container = styled.div`
   margin-right: auto;
   margin-left: auto;
   max-width: 100%;
+  box-sizing: border-box;
 
   ${p => css`
     ${DIMENSIONS.map(d =>


### PR DESCRIPTION
Border-box was missing from the Container component, causing the grid wrapper to overflow window's size.

I had to do
```javascript
const MyContainer = styled(Container)`
  box-sizing: border-box;
`
```
on my end to make this work correctly.
I also noticed this rule was already present at the `Col` component, so nothing to repair there.