### PR TITLE
Fix TypeScript not being able to read declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/react-awesome-styled-grid.cjs.js",
   "module": "lib/react-awesome-styled-grid.es.js",
   "browser": "lib/react-awesome-styled-grid.js",
+  "types": "types/index.d.ts",
   "files": [
     "lib"
   ],
@@ -47,6 +48,7 @@
     "@babel/plugin-transform-runtime": "7.4.4",
     "@babel/preset-env": "7.4.4",
     "@babel/preset-react": "7.0.0",
+    "@types/react": "^16.9.2",
     "all-contributors-cli": "6.4.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
@@ -74,7 +76,8 @@
     "rollup-plugin-babel": "4.3.2",
     "rollup-plugin-node-resolve": "4.2.4",
     "rollup-plugin-uglify": "6.0.2",
-    "styled-components": "4.2.0"
+    "styled-components": "4.2.0",
+    "typescript": "^3.5.3"
   },
   "jest": {
     "coverageDirectory": "./coverage/",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "browser": "lib/react-awesome-styled-grid.js",
   "types": "types/index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "types"
   ],
   "scripts": {
     "build": "rollup -c",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+type IGridBreakpoints = 'xs' | 'sx' | 'md' | 'lg' | 'xl';
+type IGridXSSizes = 1 | 2 | 3 | 4 | '1' | '2' | '3' | '4';
+type IGridSMSizes = IGridXSSizes | 5 | 6 | 7 | 8 | '5' | '6' | '7' | '8';
+type IGridMDSizes = IGridSMSizes;
+type IGridLGSizes = IGridMDSizes | 9 | 10 | 11 | 12 | '9' | '10' | '11' | '12';
+type IGridXLSizes = IGridLGSizes;
+
+interface IOffsetOptions {
+  xs?: IGridXSSizes;
+  sm?: IGridSMSizes;
+  md?: IGridMDSizes;
+  lg?: IGridLGSizes;
+  xl?: IGridXLSizes;
+}
+
+interface IGridContainerProps {
+  debug?: boolean;
+  fluid?:boolean;
+  children: React.ReactNode;
+}
+
+interface IGridRowProps {
+  reverse?: number | IGridBreakpoints[];
+  debug?: boolean;
+  children: React.ReactNode;
+}
+
+interface IGridColProps {
+  xs?: IGridXSSizes;
+  sm?: IGridSMSizes;
+  md?: IGridMDSizes;
+  lg?: IGridLGSizes;
+  xl?: IGridXLSizes;
+  offset?: number | IOffsetOptions;
+  reverse?: number | IGridBreakpoints[];
+  noGutter?: boolean;
+  debug?: boolean;
+  children: React.ReactNode;
+}
+
+export const Container: React.FC<IGridContainerProps>;
+export const Row: React.FC<IGridRowProps>;
+export const Col: React.FC<IGridColProps>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,9 +1384,22 @@
   version "11.13.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.10.tgz#4df59e5966b56f512bac98898bcbee5067411f0f"
 
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
+
+"@types/react@^16.9.2":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
+  integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -3172,6 +3185,11 @@ cssstyle@^1.0.0:
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -9259,6 +9277,11 @@ typedarray@^0.0.6:
 typescript@3.3.4000:
   version "3.3.4000"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
+
+typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
With my last commit, I hadn't seen the "files" array in the package.json which made it that the types folder is not included in the npm package so that is why still as of now no types available so with this commit npm will publish the types folder to the registry.