### PR TITLE
fix: fix row margins

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
-    "testPathIgnorePatterns" : [
+    "testPathIgnorePatterns": [
       "<rootDir>/.docz",
       "<rootDir>/src/gatsby-theme-docz/"
     ]

--- a/src/components/__tests__/__snapshots__/row.test.js.snap
+++ b/src/components/__tests__/__snapshots__/row.test.js.snap
@@ -13,7 +13,6 @@ exports[`<Row /> should render default style correctly 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  max-width: 100%;
 }
 
 @media only screen and (min-width:1rem) {

--- a/src/components/grid/row.js
+++ b/src/components/grid/row.js
@@ -8,7 +8,6 @@ const Row = styled.div`
   display: flex;
   flex: 1 0 auto;
   flex-wrap: wrap;
-  max-width: 100%;
   
   ${p => css`
     ${DIMENSIONS.map(d =>


### PR DESCRIPTION
The `max-width` attribute is making the row shift to the left when using negative margins for the rows. 

Before: 
![image](https://user-images.githubusercontent.com/19496473/71020376-ef6bcc00-20da-11ea-9cf9-47e14c0e0055.png)

After:
![image](https://user-images.githubusercontent.com/19496473/71020408-04e0f600-20db-11ea-9889-7250188e95b2.png)
