### PR TITLE
Fix max-width of row with flex-shrink

### DIFF
--- a/src/components/__tests__/__snapshots__/row.test.js.snap
+++ b/src/components/__tests__/__snapshots__/row.test.js.snap
@@ -7,9 +7,9 @@ exports[`<Row /> should render default style correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;

--- a/src/components/grid/row.js
+++ b/src/components/grid/row.js
@@ -6,7 +6,7 @@ import config, { DIMENSIONS } from '../../config'
 const Row = styled.div`
   box-sizing: border-box;
   display: flex;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   
   ${p => css`


### PR DESCRIPTION
Removing the `max-width` from the row in the previous commit introduced another bug. Depending  on the content, the nested row overflows the parent column.

By adding `flex-shrink: 1` or simply `flex: 1 1 auto`, the row contains itself to its parent container. 

![image](https://user-images.githubusercontent.com/19496473/72155373-c5cc5a80-3391-11ea-92b8-d500eb5a82cf.png)

![image](https://user-images.githubusercontent.com/19496473/72155480-f7ddbc80-3391-11ea-8697-4aaebd6c7963.png)
