### PR TITLE
Add new prop

### DIFF
--- a/src/components/__tests__/col.test.js
+++ b/src/components/__tests__/col.test.js
@@ -6,8 +6,20 @@ import 'jest-styled-components'
 
 describe('<Col />', () => {
   it('should render default style correctly', () => {
-    const tree = renderer.create(<Col />).toJSON()
-    expect(tree).toMatchSnapshot()
+    const tree = renderer.create(<Col />)
+    const testInstance = tree.root
+    const element = testInstance.findByType('div')
+
+    expect(element.type).toBe('div')
+    expect(tree.toJSON()).toMatchSnapshot()
+  })
+
+  it('should render a custom element', () => {
+    const tree = renderer.create(<Col component='section' />)
+    const testInstance = tree.root
+    const element = testInstance.findByType('section')
+
+    expect(element.type).toBe('section')
   })
 
   it('should have no gutter', () => {

--- a/src/components/__tests__/container.test.js
+++ b/src/components/__tests__/container.test.js
@@ -6,8 +6,20 @@ import 'jest-styled-components'
 
 describe('<Container />', () => {
   it('should render default style correctly', () => {
-    const tree = renderer.create(<Container />).toJSON()
-    expect(tree).toMatchSnapshot()
+    const tree = renderer.create(<Container />)
+    const testInstance = tree.root
+    const element = testInstance.findByType('div')
+
+    expect(element.type).toBe('div')
+    expect(tree.toJSON()).toMatchSnapshot()
+  })
+
+  it('should render a custom element', () => {
+    const tree = renderer.create(<Container component='main' />)
+    const testInstance = tree.root
+    const element = testInstance.findByType('main')
+
+    expect(element.type).toBe('main')
   })
 
   it('should have a max-width when it is a fluid container', () => {
@@ -35,7 +47,7 @@ describe('<Container />', () => {
 
   it('should have different style when it`s debug props is true', () => {
     const tree = renderer.create(<Container debug />).toJSON()
-    expect(tree).toHaveStyleRule('background-color', '#5901ad40')  
+    expect(tree).toHaveStyleRule('background-color', '#5901ad40')
     expect(tree).toHaveStyleRule('outline', '#fff solid 1px')
   })
 

--- a/src/components/__tests__/row.test.js
+++ b/src/components/__tests__/row.test.js
@@ -6,8 +6,20 @@ import 'jest-styled-components'
 
 describe('<Row />', () => {
   it('should render default style correctly', () => {
-    const tree = renderer.create(<Row />).toJSON()
-    expect(tree).toMatchSnapshot()
+    const tree = renderer.create(<Row />)
+    const testInstance = tree.root
+    const element = testInstance.findByType('div')
+
+    expect(element.type).toBe('div')
+    expect(tree.toJSON()).toMatchSnapshot()
+  })
+
+  it('should render a custom element', () => {
+    const tree = renderer.create(<Row component='section' />)
+    const testInstance = tree.root
+    const element = testInstance.findByType('section')
+
+    expect(element.type).toBe('section')
   })
 
   it('should have a reverse direction for each media', () => {

--- a/src/components/grid/col.js
+++ b/src/components/grid/col.js
@@ -1,8 +1,9 @@
 import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import config, { DIMENSIONS } from '../../config'
+import { createElementForStyle } from '../../helpers/createElementForStyle'
 
-const Col = styled.div`
+const Col = styled(createElementForStyle)`
   box-sizing: border-box;
   flex: 1 0 auto;
   max-width: 100%;
@@ -83,6 +84,10 @@ const boolOrArray = PropTypes.oneOfType([
   PropTypes.array
 ])
 
+Col.defaultProps = {
+  component: 'div'
+}
+
 Col.propTypes = {
   xs: numberOrString,
   sm: numberOrString,
@@ -95,7 +100,8 @@ Col.propTypes = {
   reverse: boolOrArray,
   noGutter: PropTypes.bool,
   children: PropTypes.node,
-  debug: PropTypes.bool
+  debug: PropTypes.bool,
+  component: PropTypes.elementType
 }
 
 export default Col

--- a/src/components/grid/col.js
+++ b/src/components/grid/col.js
@@ -48,13 +48,13 @@ const Col = styled.div`
     ? DIMENSIONS.map(d => config(p).breakpoints[d] && config(p).media[d]`${p.align[d] && `align-items: ${p.align[d]}`}`)
     : `align-items: ${p.align};`}
   `}
-  
+
   ${p => p.justify && css`
     ${typeof p.justify === 'object'
     ? DIMENSIONS.map(d => config(p).breakpoints[d] && config(p).media[d]`${p.justify[d] && `justify-content: ${p.justify[d]}`}`)
     : `justify-content: ${p.justify};`}
   `}
-  
+
   ${({ debug }) => debug && css`
     background-color: #5901ad40;
     outline: #fff solid 1px;

--- a/src/components/grid/container.js
+++ b/src/components/grid/container.js
@@ -20,7 +20,7 @@ const Container = styled.div`
       padding-right: ${config(p).paddingWidth[ d ]}rem;
     `)}
   `}
-  
+
 
   ${p => !p.fluid && css`
     ${DIMENSIONS.map(d =>

--- a/src/components/grid/container.js
+++ b/src/components/grid/container.js
@@ -2,12 +2,13 @@ import PropTypes from 'prop-types'
 import styled, {
   css
 } from 'styled-components'
+import { createElementForStyle } from '../../helpers/createElementForStyle'
 
 import config, {
   DIMENSIONS
 } from '../../config'
 
-const Container = styled.div`
+const Container = styled(createElementForStyle)`
   margin-right: auto;
   margin-left: auto;
   max-width: 100%;
@@ -37,10 +38,15 @@ const Container = styled.div`
 
 Container.displayName = 'Container'
 
+Container.defaultProps = {
+  component: 'div'
+}
+
 Container.propTypes = {
   fluid: PropTypes.bool,
   children: PropTypes.node,
-  debug: PropTypes.bool
+  debug: PropTypes.bool,
+  component: PropTypes.elementType
 }
 
 export default Container

--- a/src/components/grid/row.js
+++ b/src/components/grid/row.js
@@ -31,7 +31,7 @@ const Row = styled.div`
     ? DIMENSIONS.map(d => config(p).breakpoints[d] && config(p).media[d]`${p.align[d] && `align-items: ${p.align[d]}`}`)
     : `align-items: ${p.align};`}
   `}
-  
+
   ${p => p.justify && css`
     ${typeof p.justify === 'object'
     ? DIMENSIONS.map(d => config(p).breakpoints[d] && config(p).media[d]`${p.justify[d] && `justify-content: ${p.justify[d]}`}`)

--- a/src/components/grid/row.js
+++ b/src/components/grid/row.js
@@ -1,14 +1,14 @@
-
 import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import config, { DIMENSIONS } from '../../config'
+import { createElementForStyle } from '../../helpers/createElementForStyle'
 
-const Row = styled.div`
+const Row = styled(createElementForStyle)`
   box-sizing: border-box;
   display: flex;
   flex: 1 0 auto;
   flex-wrap: wrap;
-  
+
   ${p => css`
     ${DIMENSIONS.map(d =>
     config(p).container[ d ] && config(p).media[ d ]`
@@ -56,12 +56,17 @@ const stringOrObject = PropTypes.oneOfType([
   PropTypes.object
 ])
 
+Row.defaultProps = {
+  component: 'div'
+}
+
 Row.propTypes = {
   reverse: boolOrArray,
   align: stringOrObject,
   justify: stringOrObject,
   children: PropTypes.node,
-  debug: PropTypes.bool
+  debug: PropTypes.bool,
+  component: PropTypes.elementType
 }
 
 export default Row

--- a/src/docs/props.mdx
+++ b/src/docs/props.mdx
@@ -7,37 +7,40 @@ route: /props
 
 ## Container
 
-| prop      | type    | description                |
-|-----------|---------|--------------------------- |
-| fluid     | boolean | makes container full-width |
-| debug     | boolean | enables debug              |
-| children  | node    | content                    |
+| prop      | type         | description                                 |
+|-----------|--------------|-------------------------------------------- |
+| fluid     | boolean      | makes container full-width                  |
+| debug     | boolean      | enables debug                               |
+| children  | node         | content                                     |
+| component | element type | create a custom element or default is `div` |
 
 ## Row
-| prop      | type             | description                          |
-|-----------|------------------|--------------------------------------|
-| justify   | string or object | align the content horizontally       |
-| align     | string or object | align the content vertically         |
-| reverse   | number or array  | reverses the direction of the row    |
-| debug     | boolean          | enables debug                        |
-| children  | node             | content                              |
+| prop      | type             | description                             |
+|-----------|------------------|---------------------------------------- |
+| justify   | string or object | align the content horizontally          |
+| align     | string or object | align the content vertically            |
+| reverse   | number or array  | reverses the direction of the row       |
+| debug     | boolean          | enables debug                           |
+| children  | node             | content                                 |
+| component | element type | create a custom element or default is `div` |
 
 ## Col
 
-| prop      | type             | description                                |
-|-----------|------------------|--------------------------------------------|
-| xs        | number or string | sets the number of columns on screens *xs* |
-| sm        | number or string | sets the number of columns on screens *sm* |
-| md        | number or string | sets the number of columns on screens *md* |
-| lg        | number or string | sets the number of columns on screens *lg* |
-| xl        | number or string | sets the number of columns on screens *xl* |
-| justify   | string or object | align the content horizontally             |
-| align     | string or object | align the content vertically               |
-| offset    | number or object | sets the number of the offset columns      |
-| reverse   | number or array  | reverses the direction of the column       |
-| noGutter  | boolean          | removes the gutter                         |
-| debug     | boolean          | enables debug                              |
-| children  | node             | content                                    |
+| prop      | type             | description                                 |
+|-----------|------------------|-------------------------------------------- |
+| xs        | number or string | sets the number of columns on screens *xs*  |
+| sm        | number or string | sets the number of columns on screens *sm*  |
+| md        | number or string | sets the number of columns on screens *md*  |
+| lg        | number or string | sets the number of columns on screens *lg*  |
+| xl        | number or string | sets the number of columns on screens *xl*  |
+| justify   | string or object | align the content horizontally              |
+| align     | string or object | align the content vertically                |
+| offset    | number or object | sets the number of the offset columns       |
+| reverse   | number or array  | reverses the direction of the column        |
+| noGutter  | boolean          | removes the gutter                          |
+| debug     | boolean          | enables debug                               |
+| children  | node             | content                                     |
+| component | element type     | create a custom element or default is `div` |
 
 ## Visible
 | prop     | type    | description                                          |
@@ -57,7 +60,7 @@ route: /props
 | md       | boolean | indicates that past content will only be hidden on the screen *md* |
 | lg       | boolean | indicates that past content will only be hidden on the screen *lg* |
 | xl       | boolean | indicates that past content will only be hidden on the screen *xl* |
-| children | node    | content    
+| children | node    | content
 
 ## ScreenClass
 | prop     | type    | description                                          |

--- a/src/helpers/createElementForStyle.js
+++ b/src/helpers/createElementForStyle.js
@@ -1,0 +1,4 @@
+import { createElement } from 'react'
+
+export const createElementForStyle = ({ component, children, ...props }) =>
+  createElement(component, props, children)


### PR DESCRIPTION
At work, we choose this library to implement our design system, and I could see something to increase this library.

To have better semantic code, I added a new `prop` for `Container`, `Row` and `Col` components.

With this `prop`, it's possible to choose the type of element you want to create.

So if I want to render a `<Container />` with `main` element I can pass:

`<Container content="main" />`