### PR TITLE
Fix IGridBreakpoints

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type IGridBreakpoints = 'xs' | 'sx' | 'md' | 'lg' | 'xl';
+type IGridBreakpoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 interface IAlignOrJustifyOptions {
   xs?: string;


### PR DESCRIPTION
In this Pr, I am correcting IGridBreackpoints that have a typo. was written `sx` instead of` sm`.