### PR TITLE
Possible typo in index.d.ts interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,7 +78,7 @@ interface IConfig {
   gutterWidth: Record<IGridBreakpoints, number>;
   paddingWidth: Record<IGridBreakpoints, number>;
   container: Record<IGridBreakpoints, number>;
-  breakPoints: Record<IGridBreakpoints, number>;
+  breakpoints: Record<IGridBreakpoints, number>;
 }
 
 type IConfigProps = ThemeProps<{awesomegrid: Partial<IConfig>}>;


### PR DESCRIPTION
As we can see in config it may be a simple typo:
https://github.com/santosfrancisco/react-awesome-styled-grid/blob/master/src/config.js#L35

We have `breakpoint` in the configuration instead of `breakPoint`. During typing our custom config with `IConfig` we can meet error which looks similar to this one:

> Object literal may only specify known properties, but 'breakpoints' does not exist in type...

When we change to `breakPoint` as interface wish to do there is no effect in code as custom breakpoints.

Temp workaround:

```
type CustomConfig = Omit<IConfig, 'breakPoints'> & {
  breakpoints: Record<IGridBreakpoints, number>;
}
```